### PR TITLE
Add Participate block to boilerplate

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,24 @@
                     url:        "https://www.mnot.net/",
     			}
           ],
+          
+          otherLinks: [{
+            key: 'Participate',
+            data: [{
+                      value: 'We are on Github.',
+                      href: 'https://github.com/w3ctag/web-https'
+                  }, {
+                      value: 'File a bug.',
+                      href: 'https://github.com/w3ctag/web-https/issues'
+                  }, {
+                      value: 'Commit history.',
+                      href: 'https://github.com/w3ctag/web-https/commits/gh-pages'
+                  }, {
+                      value: 'Mailing list.',
+                      href: 'http://lists.w3.org/Archives/Public/www-tag/'
+            }]
+          }],
+          
           wg:           "Technical Architecture Group",
           wgURI:        "http://www.w3.org/2001/tag/",
           wgPublicList: "www-tag",


### PR DESCRIPTION
This PR adds "Participate" boilerplate data to the document such as links to the GH Issues, comment list, etc.
