### PR TITLE
Use https:// with as many URLs as possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Securing the Web</title>
     <meta charset='utf-8'>
-    <script src='//www.w3.org/Tools/respec/respec-w3c-common'
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common'
             async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
@@ -26,14 +26,14 @@
                       href: 'https://github.com/w3ctag/web-https/commits/gh-pages'
                   }, {
                       value: 'Mailing list.',
-                      href: 'http://lists.w3.org/Archives/Public/www-tag/'
+                      href: 'https://lists.w3.org/Archives/Public/www-tag/'
             }]
           }],
 
           wg:           "Technical Architecture Group",
-          wgURI:        "http://www.w3.org/2001/tag/",
+          wgURI:        "https://www.w3.org/2001/tag/",
           wgPublicList: "www-tag",
-          wgPatentURI:  "http://www.w3.org/2001/tag/disclosures",
+          wgPatentURI:  "https://www.w3.org/2001/tag/disclosures",
           edDraftURI: "https://w3ctag.github.io/web-https/",
           noTOC: false,
           localBiblio:  {
@@ -58,15 +58,15 @@
       <p>Its primary audience is W3C participants.</p>
   </section>
   <section id="sotd">
-      <p>This document has been produced by the <a href="http://www.w3.org/2001/tag/">W3C Technical 
+      <p>This document has been produced by the <a href="https://www.w3.org/2001/tag/">W3C Technical 
       Architecture Group (TAG)</a>. The TAG approved this finding at its 
-      <a href="http://www.w3.org/2001/tag/2015/01/22-minutes">22&nbsp;January&nbsp;2015 teleconference</a>.
+      <a href="https://www.w3.org/2001/tag/2015/01/22-minutes">22&nbsp;January&nbsp;2015 teleconference</a>.
       <a href="/2001/tag/findings">Additional TAG findings</a>, both accepted and in draft state, may 
       also be available. The TAG may incorporate this and other findings into future versions of the
       <a href="#AWWW">[AWWW]</a>.
       Please send comments on this finding to the publicly archived TAG mailing list 
       <a href="mailto:www-tag@w3.org">www-tag@w3.org</a> 
-      (<a href="http://lists.w3.org/Archives/Public/www-tag/">archive</a>).</p>
+      (<a href="https://lists.w3.org/Archives/Public/www-tag/">archive</a>).</p>
 
   </section>
 
@@ -162,7 +162,7 @@
         Many new Web platform features offer increased capabilities, access to data and richer
         functionality. Some of these "powerful" features also have significant security and privacy
         implications, and Working Groups should consider whether they ought only be used over an
-        encrypted connection. The <a href="http://www.w3.org/2011/webappsec/">Web Applications
+        encrypted connection. The <a href="https://www.w3.org/2011/webappsec/">Web Applications
         Security Working Group</a> (WebAppSec) has begun work on [[powerful-features]] to document
         best practices in this area.
     </p></dd>
@@ -321,10 +321,10 @@
 
     <p>
         This finding builds upon and explicitly acknowledges the Internet Architecture Board’s <a
-        href="http://www.iab.org/2014/11/14/iab-statement-on-internet-confidentiality/">Statement
+        href="https://www.iab.org/2014/11/14/iab-statement-on-internet-confidentiality/">Statement
         on Internet Confidentiality</a>, the <a href="https://www.w3.org/2014/strint/">STRINT
         Workshop</a>, and the Chromium Security Team’s “<a
-        href="http://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-
+        href="https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-
         features" >Prefer Secure Origins For Powerful New Features</a>”.
     </p>
   </section>


### PR DESCRIPTION
This updates `index.html` with as many `https://` URLs as possible.

I chose to use https://www.w3.org because there's a valid cert there for it, but it's worth noting that it redirects away to http://www.w3.org. (Seems like a good opportunity to nudge the right person at the W3C about that...)
