### PR TITLE
Enforce HTTPS for the live URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,15 @@
           }
       };
     </script>
+    
+    <!-- Enforce an HTTPS URL, but only in production. -->
+    <script type="text/javascript">
+        var enforce = "w3ctag.github.io";
+        if ((enforce == window.location.host) && (window.location.protocol != "https:"))
+            window.location.protocol = "https";
+    </script>
+    
+    <link rel="canonical" href="https://w3ctag.github.io/web-https/" />
 </head>
 <body>
   <section id="abstract">


### PR DESCRIPTION
This makes `http://w3ctag.github.io/web-https/` redirect (via client-side JS) to `https://w3ctag.github.io/web-https/`. It doesn't affect the app in development, or on other URLs.

It also sets a `rel="canonical"` URL of the HTTPS version of the URL, so that Google et al will start linking to it directly at that URL. Ideally, links to the `http://` URL just don't get created in the first place.
